### PR TITLE
Added a rolling file like feature.

### DIFF
--- a/Serilog.Sinks.AzureBlobStorage.UnitTest/BlobNameFactoryUT.cs
+++ b/Serilog.Sinks.AzureBlobStorage.UnitTest/BlobNameFactoryUT.cs
@@ -1,0 +1,79 @@
+using System;
+using Xunit;
+
+namespace Serilog.Sinks.AzureBlobStorage.UnitTest
+{
+    public class BlobNameFactoryUT
+    {
+        [Fact(DisplayName = "Should throw validation exception due to invalid format characters.")]
+        public void InvalidFormatCharacters()
+        {
+            var dtoToApply = new DateTimeOffset(2018, 11, 5, 8, 30, 0, new TimeSpan(-5,0,0));
+
+            Assert.Throws<ArgumentException>(() => new BlobNameFactory(@"{xx}\name.txt"));
+        }
+
+        [Fact(DisplayName = "Should throw validation exception due to format characters out of order.")]
+        public void OutOfOrderFormatCharacters()
+        {
+            var dtoToApply = new DateTimeOffset(2018, 11, 5, 8, 30, 0, new TimeSpan(-5, 0, 0));
+
+            Assert.Throws<ArgumentException>(() => new BlobNameFactory(@"{yyyy}\{dd}\{MM}\name.txt"));
+        }
+
+        [Fact(DisplayName = "Should result in same filename.")]
+        public void SameName()
+        {
+            var dtoToApply = new DateTimeOffset(2018, 11, 5, 8, 30, 0, new TimeSpan(-5, 0, 0));
+            var bn = new BlobNameFactory("samename.txt");
+
+            var result = bn.GetBlobName(dtoToApply);
+
+            Assert.Equal("samename.txt", result);
+        }
+
+        [Fact(DisplayName = "Should parse into year, month folder with day as filename.")]
+        public void YearMonthFolderDayName()
+        {
+            var dtoToApply = new DateTimeOffset(2018, 11, 5, 8, 30, 0, new TimeSpan(-5, 0, 0));
+            var bn = new BlobNameFactory("webhook/{yyyy}/{MM}/{dd}.txt");
+
+            var result = bn.GetBlobName(dtoToApply);
+
+            Assert.Equal("webhook/2018/11/05.txt", result);
+        }
+
+        [Fact(DisplayName = "Should parse into year, month, day folder with hours as filename.")]
+        public void YearMonthDayFolderHoursName()
+        {
+            var dtoToApply = new DateTimeOffset(2018, 11, 5, 8, 30, 0, new TimeSpan(-5, 0, 0));
+            var bn = new BlobNameFactory("webhook/{yyyy}/{MM}/{dd}/{HH}.txt");
+
+            var result = bn.GetBlobName(dtoToApply);
+
+            Assert.Equal("webhook/2018/11/05/08.txt", result);
+        }
+
+        [Fact(DisplayName = "Should parse into year, month, day, hours folder with minutes as filename.")]
+        public void YearMonthDayHoursFolderMinutesName()
+        {
+            var dtoToApply = new DateTimeOffset(2018, 11, 5, 8, 30, 0, new TimeSpan(-5, 0, 0));
+            var bn = new BlobNameFactory("webhook/{yyyy}/{MM}/{dd}/{HH}/{mm}.txt");
+
+            var result = bn.GetBlobName(dtoToApply);
+
+            Assert.Equal("webhook/2018/11/05/08/30.txt", result);
+        }
+
+        [Fact(DisplayName = "Should parse into year, month, and day into single folder with hours as filename.")]
+        public void YearMonthDayOneFolderHoursName()
+        {
+            var dtoToApply = new DateTimeOffset(2018, 11, 5, 8, 30, 0, new TimeSpan(-5, 0, 0));
+            var bn = new BlobNameFactory("webhook/{yyyyMMdd}/{HH}.txt");
+
+            var result = bn.GetBlobName(dtoToApply);
+
+            Assert.Equal("webhook/20181105/08.txt", result);
+        }
+    }
+}

--- a/Serilog.Sinks.AzureBlobStorage.UnitTest/Serilog.Sinks.AzureBlobStorage.UnitTest.csproj
+++ b/Serilog.Sinks.AzureBlobStorage.UnitTest/Serilog.Sinks.AzureBlobStorage.UnitTest.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\Serilog.Sinks.AzureBlobStorage\Serilog.Sinks.AzureBlobStorage.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/serilog-sinks-azureblobstorage.sln
+++ b/serilog-sinks-azureblobstorage.sln
@@ -17,6 +17,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AzureBlobStorage.TestClient
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Test", "Test", "{BD6DDC9A-B4A7-49E9-99F9-1EB7C462BF67}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Sinks.AzureBlobStorage.UnitTest", "Serilog.Sinks.AzureBlobStorage.UnitTest\Serilog.Sinks.AzureBlobStorage.UnitTest.csproj", "{F94B805F-E056-4921-8EC2-0B0F4849BBE8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -31,12 +33,17 @@ Global
 		{500938EC-A458-4892-9BB3-4083EACB6534}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{500938EC-A458-4892-9BB3-4083EACB6534}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{500938EC-A458-4892-9BB3-4083EACB6534}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F94B805F-E056-4921-8EC2-0B0F4849BBE8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F94B805F-E056-4921-8EC2-0B0F4849BBE8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F94B805F-E056-4921-8EC2-0B0F4849BBE8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F94B805F-E056-4921-8EC2-0B0F4849BBE8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{500938EC-A458-4892-9BB3-4083EACB6534} = {BD6DDC9A-B4A7-49E9-99F9-1EB7C462BF67}
+		{F94B805F-E056-4921-8EC2-0B0F4849BBE8} = {BD6DDC9A-B4A7-49E9-99F9-1EB7C462BF67}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {73E16F7E-6DF4-4355-BF3C-73DDBBA1867E}

--- a/src/Serilog.Sinks.AzureBlobStorage/Sinks/AzureBlobStorage/AzureBlobStorageSink.cs
+++ b/src/Serilog.Sinks.AzureBlobStorage/Sinks/AzureBlobStorage/AzureBlobStorageSink.cs
@@ -31,9 +31,9 @@ namespace Serilog.Sinks.AzureBlobStorage
         readonly ITextFormatter textFormatter;        
         readonly CloudStorageAccount storageAccount;
         readonly string storageFolderName;
-        readonly string storageFileName;
         readonly bool bypassFolderCreationValidation;
         readonly ICloudBlobProvider cloudBlobProvider;
+        readonly BlobNameFactory blobNameFactory;
 
         /// <summary>
         /// Construct a sink that saves logs to the specified storage account.
@@ -66,7 +66,7 @@ namespace Serilog.Sinks.AzureBlobStorage
 
             this.storageAccount = storageAccount;
             this.storageFolderName = storageFolderName;
-            this.storageFileName = storageFileName;
+            this.blobNameFactory = new BlobNameFactory(storageFileName);
             this.bypassFolderCreationValidation = bypassFolderCreationValidation;
             this.cloudBlobProvider = cloudBlobProvider ?? new DefaultCloudBlobProvider();
         }
@@ -76,8 +76,8 @@ namespace Serilog.Sinks.AzureBlobStorage
         /// </summary>
         /// <param name="logEvent">The log event to write.</param>
         public void Emit(LogEvent logEvent)
-        {            
-            var blob = cloudBlobProvider.GetCloudBlob(storageAccount, storageFolderName, storageFileName, bypassFolderCreationValidation);
+        {
+            var blob = cloudBlobProvider.GetCloudBlob(storageAccount, storageFolderName, blobNameFactory.GetBlobName(logEvent.Timestamp), bypassFolderCreationValidation);
 
             StringBuilder sb = new StringBuilder();
             TextWriter tw = new StringWriter(sb);

--- a/src/Serilog.Sinks.AzureBlobStorage/Sinks/AzureBlobStorage/BlobNameFactory.cs
+++ b/src/Serilog.Sinks.AzureBlobStorage/Sinks/AzureBlobStorage/BlobNameFactory.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Text;
+
+namespace Serilog.Sinks.AzureBlobStorage
+{
+    /// <summary>
+    /// Produces a blob name using a given format string and a provided datetimeoffset.
+    /// The format string must only contain the date time foramt characters in the
+    /// following order: 'y', 'M', 'd', 'H', 'm'. Not all format characters must be used.
+    /// If forward slashes are used in the format string, the logs will appear to be
+    /// in folders in the azure storage explorer.
+    /// </summary>
+    public class BlobNameFactory
+    {
+        readonly char[] DATE_FORMAT_ORDER = { 'y', 'M', 'd', 'H', 'm' };
+        string baseBlobName;
+
+        public BlobNameFactory(string baseBlobName)
+        {
+            this.baseBlobName = baseBlobName ?? throw new ArgumentNullException(nameof(baseBlobName));
+
+            ValidatedBlobName();
+        }
+
+        public string GetBlobName(DateTimeOffset dtoToApply)
+        {
+            string blobName = "";
+            StringBuilder sb = new StringBuilder();
+
+            // Example:
+            // baseBlobName = webhook/{yyyy}/{MM}/{dd}/{HH}.txt
+            // on November 26, 2018 at 17:52
+            // blobName = webhook/2018/11/26/17.txt
+            int i = 0;
+            while (i < baseBlobName.Length)
+            {
+                var openBraceIndex = baseBlobName.IndexOf('{', i);
+
+                if (openBraceIndex < 0)
+                {
+                    sb.Append(baseBlobName.Substring(i));
+                    break;
+                }
+                else
+                {
+                    if (i != openBraceIndex)
+                    {
+                        sb.Append(baseBlobName.Substring(i, openBraceIndex - i));
+                        i = openBraceIndex;
+                    }
+                    
+                    var closeBraceIndex = baseBlobName.IndexOf('}', openBraceIndex);
+                    var dateFormat = baseBlobName.Substring(openBraceIndex + 1, closeBraceIndex - openBraceIndex - 1);
+                    sb.Append(dtoToApply.ToString(dateFormat));
+                    i = closeBraceIndex + 1;
+                }
+            }
+
+            blobName = sb.ToString();
+
+            return blobName;
+        }
+
+        /// <summary>
+        /// Validate the base blob name provided.
+        /// </summary>
+        private void ValidatedBlobName()
+        {
+            int j = 0;
+            int i = 0;
+            while (i < baseBlobName.Length)
+            {
+                var openBraceIndex = baseBlobName.IndexOf('{', i);
+
+                if (openBraceIndex < 0)
+                {
+                    break;
+                }
+                else
+                {
+                    // Get the date format characters within the current pair of curly braces.
+                    var closeBraceIndex = baseBlobName.IndexOf('}', openBraceIndex);
+                    var dateFormat = baseBlobName.Substring(openBraceIndex + 1, closeBraceIndex - openBraceIndex - 1);
+
+                    // Keep checking the date date format string until all characters within have been verified.
+                    int lastIndex = 0;
+                    do
+                    {
+                        // The index of the DATE_FORMAT_ORDER array is beyond the last element,
+                        // by default the base blob name is invalid.
+                        if (j >= DATE_FORMAT_ORDER.Length)
+                            throw new ArgumentException($"{nameof(baseBlobName)} has unexpected date format characters.");
+
+                        // Get the last index of the currently expected format character. If that
+                        // character is not found, then the characters are out of order or an
+                        // unexpected character was provided.
+                        lastIndex = dateFormat.LastIndexOf(DATE_FORMAT_ORDER[j++]);
+                        if (lastIndex < 0)
+                            throw new ArgumentException($"{nameof(baseBlobName)} has unexpectently encountered the format character '{DATE_FORMAT_ORDER[j - 1]}'.");
+
+                    } while (lastIndex + 1 < dateFormat.Length);
+
+                    i = closeBraceIndex + 1;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Instead of the file name being a single fixed name, the user can insert date\time format strings into the log file name. For example, the user can provide the following "storageFileName" in appsettings.json.
          "storageFileName": "webhook/{yyyy}/{MM}/{dd}/{HH}.txt"

The code will use the logtimestamp value to generate the blobname. For batching, the timestamp of the last event in the batch shall be applied.
