### PR TITLE
Fixed bugs in DefaultCloudBlobProvider and take Max block size and Max block count into account

### DIFF
--- a/serilog-sinks-azureblobstorage.sln
+++ b/serilog-sinks-azureblobstorage.sln
@@ -15,6 +15,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Test", "Test", "{BD6DDC9A-B
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Serilog.Sinks.AzureBlobStorage.UnitTest", "tests\Serilog.Sinks.AzureBlobStorage.UnitTest\Serilog.Sinks.AzureBlobStorage.UnitTest.csproj", "{F94B805F-E056-4921-8EC2-0B0F4849BBE8}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebApplication11", "..\WebApplication11\WebApplication11\WebApplication11.csproj", "{809B9BCD-05ED-449E-8FB8-5A9569CBA283}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -29,6 +31,10 @@ Global
 		{F94B805F-E056-4921-8EC2-0B0F4849BBE8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F94B805F-E056-4921-8EC2-0B0F4849BBE8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F94B805F-E056-4921-8EC2-0B0F4849BBE8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{809B9BCD-05ED-449E-8FB8-5A9569CBA283}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{809B9BCD-05ED-449E-8FB8-5A9569CBA283}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{809B9BCD-05ED-449E-8FB8-5A9569CBA283}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{809B9BCD-05ED-449E-8FB8-5A9569CBA283}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/serilog-sinks-azureblobstorage.sln
+++ b/serilog-sinks-azureblobstorage.sln
@@ -15,8 +15,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Test", "Test", "{BD6DDC9A-B
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Serilog.Sinks.AzureBlobStorage.UnitTest", "tests\Serilog.Sinks.AzureBlobStorage.UnitTest\Serilog.Sinks.AzureBlobStorage.UnitTest.csproj", "{F94B805F-E056-4921-8EC2-0B0F4849BBE8}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebApplication11", "..\WebApplication11\WebApplication11\WebApplication11.csproj", "{809B9BCD-05ED-449E-8FB8-5A9569CBA283}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -31,10 +29,6 @@ Global
 		{F94B805F-E056-4921-8EC2-0B0F4849BBE8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F94B805F-E056-4921-8EC2-0B0F4849BBE8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F94B805F-E056-4921-8EC2-0B0F4849BBE8}.Release|Any CPU.Build.0 = Release|Any CPU
-		{809B9BCD-05ED-449E-8FB8-5A9569CBA283}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{809B9BCD-05ED-449E-8FB8-5A9569CBA283}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{809B9BCD-05ED-449E-8FB8-5A9569CBA283}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{809B9BCD-05ED-449E-8FB8-5A9569CBA283}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Serilog.Sinks.AzureBlobStorage/LoggerConfigurationAzureBlobStorageExtensions.cs
+++ b/src/Serilog.Sinks.AzureBlobStorage/LoggerConfigurationAzureBlobStorageExtensions.cs
@@ -360,7 +360,7 @@ namespace Serilog
                 }
                 else
                 {
-                    storageAccount = new CloudStorageAccount(credentials, null, null, blobEndpoint, null);
+                    storageAccount = new CloudStorageAccount(credentials, blobEndpoint, null, null, null);
                 }
 
                 // We set bypassBlobCreationValidation to true explicitly here as the the SAS URL might not have enough permissions to query if the blob exists.

--- a/src/Serilog.Sinks.AzureBlobStorage/Properties/AssemblyInfo.cs
+++ b/src/Serilog.Sinks.AzureBlobStorage/Properties/AssemblyInfo.cs
@@ -10,3 +10,5 @@ using System.Runtime.CompilerServices;
                                                        "d18dbf6d5a25af5ce9016f281014d79dc3b4201ac646c451830fc7e61a2dfd633d34c39f87b818" +
                                                        "94191652df5ac63cc40c77f3542f702bda692e6e8a9158353df189007a49da0f3cfd55eb250066" +
                                                        "b19485ec")]
+
+[assembly: InternalsVisibleTo("Serilog.Sinks.AzureBlobStorage.UnitTest")]

--- a/src/Serilog.Sinks.AzureBlobStorage/Sinks/AzureBlobProvider/ICloudBlobProvider.cs
+++ b/src/Serilog.Sinks.AzureBlobStorage/Sinks/AzureBlobProvider/ICloudBlobProvider.cs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Threading.Tasks;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;
 
@@ -20,6 +21,6 @@ namespace Serilog.Sinks.AzureBlobStorage.AzureBlobProvider
 {
     public interface ICloudBlobProvider
     {
-        CloudAppendBlob GetCloudBlob(CloudStorageAccount storageAccount, string folderName, string fileName, bool bypassBlobCreationValidation);
+        Task<CloudAppendBlob> GetCloudBlobAsync(CloudStorageAccount storageAccount, string blobContainerName, string blobName, bool bypassBlobCreationValidation);
     }
 }

--- a/src/Serilog.Sinks.AzureBlobStorage/Sinks/AzureBlobStorage/DefaultAppendBlobBlockPreparer.cs
+++ b/src/Serilog.Sinks.AzureBlobStorage/Sinks/AzureBlobStorage/DefaultAppendBlobBlockPreparer.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Serilog.Events;
+using Serilog.Formatting;
+
+namespace Serilog.Sinks.AzureBlobStorage
+{
+    class DefaultAppendBlobBlockPreparer : IAppendBlobBlockPreparer
+    {
+        private static readonly int MaxAppendBlobBlockSize = 1024 * 1024 * 4;
+
+        public IEnumerable<string> PrepareAppendBlocks(ITextFormatter textFormatter, IEnumerable<LogEvent> logEvents)
+        {
+            if (textFormatter == null)
+            {
+                throw new ArgumentNullException(nameof(textFormatter));
+            }
+
+            if (logEvents == null)
+            {
+                throw new ArgumentNullException(nameof(logEvents));
+            }
+
+            List<string> blockContents = new List<string>();
+            StringBuilder currentBlockContent = new StringBuilder();
+            int currentBlockSize = 0;
+            foreach (LogEvent logEvent in logEvents)
+            {
+                using (StringWriter tempStringWriter = new StringWriter())
+                {
+                    try
+                    {
+                        textFormatter.Format(logEvent, tempStringWriter);
+                        tempStringWriter.Flush();
+                    }
+                    catch (Exception ex)
+                    {
+                        Debugging.SelfLog.WriteLine($"Exception {ex} thrown during logEvent formatting. The log event will be dropped.");
+                        continue;
+                    }
+
+                    int logEventSize = Encoding.UTF8.GetByteCount(tempStringWriter.ToString());
+                    if (logEventSize > MaxAppendBlobBlockSize)
+                    {
+                        Debugging.SelfLog.WriteLine($"LogEvent is larger than the allowed max append blob block size. The log event cannot be logged and will be dropped. The log event: {tempStringWriter}");
+                        continue;
+                    }
+
+                    if (logEventSize + currentBlockSize > MaxAppendBlobBlockSize)
+                    {
+                        //The log event does not fit in the max block size. Cut off the current block and start a new block
+                        blockContents.Add(currentBlockContent.ToString());
+                        currentBlockContent.Clear();
+                        currentBlockSize = 0;
+                    }
+
+                    //Add the log event to the block
+                    currentBlockContent.Append(tempStringWriter.ToString());
+                    currentBlockSize += logEventSize;
+                }
+            }
+
+            //in case of an empty IEnumerable<LogEvent> parameter there are no blocks to write, skip creating an empty block.
+            if (currentBlockSize != 0)
+            {
+                blockContents.Add(currentBlockContent.ToString());
+            }
+            
+
+            return blockContents;
+        }
+
+        
+    }
+}

--- a/src/Serilog.Sinks.AzureBlobStorage/Sinks/AzureBlobStorage/DefaultAppendBlobBlockWriter.cs
+++ b/src/Serilog.Sinks.AzureBlobStorage/Sinks/AzureBlobStorage/DefaultAppendBlobBlockWriter.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Blob;
+
+namespace Serilog.Sinks.AzureBlobStorage
+{
+    class DefaultAppendBlobBlockWriter : IAppendBlobBlockWriter
+    {
+
+        public async Task WriteBlocksToAppendBlobAsync(CloudAppendBlob cloudAppendBlob, IEnumerable<string> blocks)
+        {
+            if (cloudAppendBlob == null)
+            {
+                throw new ArgumentNullException(nameof(cloudAppendBlob));
+            }
+
+            if (blocks == null)
+            {
+                throw new ArgumentNullException(nameof(blocks));
+            }
+
+            foreach (string blockContent in blocks)
+            {
+                using (MemoryStream stream = new MemoryStream(Encoding.UTF8.GetBytes(blockContent)))
+                {
+                    try
+                    {
+                        await cloudAppendBlob.AppendBlockAsync(stream);
+                    }
+                    catch (StorageException ex)
+                    {
+                        Debugging.SelfLog.WriteLine($"Exception {ex} thrown while trying to append a block. Http response code {ex.RequestInformation?.HttpStatusCode} and error code {ex.RequestInformation?.ErrorCode}. If this is the second or later block in this batch there might be duplicate log entries written due to the retry mechanism.");
+                    }
+                    catch (Exception ex)
+                    {
+                        Debugging.SelfLog.WriteLine($"Exception {ex} thrown while trying to append a block. If this is the second or later block in this batch there might be duplicate log entries written due to the retry mechanism.");
+                    }
+                }
+            }
+        }
+
+    }
+}

--- a/src/Serilog.Sinks.AzureBlobStorage/Sinks/AzureBlobStorage/IAppendBlobBlockPreparer.cs
+++ b/src/Serilog.Sinks.AzureBlobStorage/Sinks/AzureBlobStorage/IAppendBlobBlockPreparer.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using Serilog.Events;
+using Serilog.Formatting;
+
+namespace Serilog.Sinks.AzureBlobStorage
+{
+    public interface IAppendBlobBlockPreparer
+    {
+        IEnumerable<string> PrepareAppendBlocks(ITextFormatter textFormatter, IEnumerable<LogEvent> logEvents);
+    }
+}

--- a/src/Serilog.Sinks.AzureBlobStorage/Sinks/AzureBlobStorage/IAppendBlobBlockWriter.cs
+++ b/src/Serilog.Sinks.AzureBlobStorage/Sinks/AzureBlobStorage/IAppendBlobBlockWriter.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.WindowsAzure.Storage.Blob;
+
+namespace Serilog.Sinks.AzureBlobStorage
+{
+    public interface IAppendBlobBlockWriter
+    {
+        Task WriteBlocksToAppendBlobAsync(CloudAppendBlob cloudAppendBlob, IEnumerable<string> blocks);
+    }
+}

--- a/tests/Serilog.Sinks.AzureBlobStorage.UnitTest/DefaultAppendBlobBlockPreparerUT.cs
+++ b/tests/Serilog.Sinks.AzureBlobStorage.UnitTest/DefaultAppendBlobBlockPreparerUT.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Serilog.Events;
+using Serilog.Formatting;
+using Xunit;
+
+namespace Serilog.Sinks.AzureBlobStorage.UnitTest
+{
+    public class DefaultAppendBlobBlockPreparerUT
+    {
+        readonly DefaultAppendBlobBlockPreparer _defaultAppendBlobBlockPreparer;
+        readonly ITextFormatter _defaultTextFormatter;
+        readonly IEnumerable<LogEvent> _emptyLogEventEnumerable;
+
+        readonly LogEvent _tooLargeLogEvent= new LogEvent(DateTimeOffset.UtcNow, LogEventLevel.Information, null, MessageTemplate.Empty, new[] { new LogEventProperty("BigProp", new Serilog.Events.ScalarValue(new string('*', 1024 * 1024 * 6))) });
+        readonly LogEvent _largeLogEvent = new LogEvent(DateTimeOffset.UtcNow, LogEventLevel.Information, null, MessageTemplate.Empty, new[] { new LogEventProperty("BigProp", new Serilog.Events.ScalarValue(new string ('*', 1024 * 512))) });
+
+        public DefaultAppendBlobBlockPreparerUT()
+        {
+            _defaultAppendBlobBlockPreparer = new DefaultAppendBlobBlockPreparer();
+            _defaultTextFormatter = new Serilog.Formatting.Json.JsonFormatter();
+            _emptyLogEventEnumerable = Enumerable.Empty<LogEvent>();
+        }
+
+        [Fact(DisplayName = "Should throw validation exception due to missing ITextFormatter instance.")]
+        public void MissingITextFormatterInstance()
+        {
+            Assert.Throws<ArgumentNullException>(() => _defaultAppendBlobBlockPreparer.PrepareAppendBlocks(null, _emptyLogEventEnumerable));
+        }
+
+        [Fact(DisplayName = "Should throw validation exception due to missing IEnumerable<LogEvent> instance.")]
+        public void MissingIEnumerableLogEventsInstance()
+        {
+            Assert.Throws<ArgumentNullException>(() => _defaultAppendBlobBlockPreparer.PrepareAppendBlocks(_defaultTextFormatter, null));
+        }
+
+        [Fact(DisplayName = "Should return an empty IEnumerable<string> when an empty IEnumberable<LogEvent> goes in.")]
+        public void ReturnEmptyResultWhenInputIsEmpty()
+        {
+            var preparedResult = _defaultAppendBlobBlockPreparer.PrepareAppendBlocks(_defaultTextFormatter, _emptyLogEventEnumerable);
+
+            Assert.Empty(preparedResult);
+        }
+
+        [Fact(DisplayName = "Should drop LogEvents that when formatted are greater than 4MB")]
+        public void DropTooLargeLogEvents()
+        {
+            var logEvents = new[] { _tooLargeLogEvent };
+
+            var preparedResult = _defaultAppendBlobBlockPreparer.PrepareAppendBlocks(_defaultTextFormatter, logEvents);
+
+            Assert.Empty(preparedResult);
+        }
+
+        [Fact(DisplayName = "Should return multiple blocks when the log events overflow the 4mb block size.")]
+        public void ReturnMultipleBlocksWhenLogEventsOverflow4MB()
+        {
+            var logEvents = new[] { _largeLogEvent, _largeLogEvent , _largeLogEvent , _largeLogEvent , _largeLogEvent , _largeLogEvent , _largeLogEvent, _largeLogEvent, _largeLogEvent };
+
+            var preparedResult = _defaultAppendBlobBlockPreparer.PrepareAppendBlocks(_defaultTextFormatter, logEvents);
+
+            Assert.NotEmpty(preparedResult);
+            Assert.True(preparedResult.Count() == 2);
+        }
+
+        [Fact(DisplayName = "Should return single block when the log events stay below the formatted size of 4mb.")]
+        public void ReturnSinglelocksWhenLogEventsStayBelow4MBLimit()
+        {
+            var logEvents = new[] { _largeLogEvent, _largeLogEvent, _largeLogEvent};
+
+            var preparedResult = _defaultAppendBlobBlockPreparer.PrepareAppendBlocks(_defaultTextFormatter, logEvents);
+
+            Assert.NotEmpty(preparedResult);
+            Assert.True(preparedResult.Count() == 1);
+        }
+
+    }
+}

--- a/tests/Serilog.Sinks.AzureBlobStorage.UnitTest/DefaultAppendBlobBlockWriterUT.cs
+++ b/tests/Serilog.Sinks.AzureBlobStorage.UnitTest/DefaultAppendBlobBlockWriterUT.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FakeItEasy;
+using Microsoft.WindowsAzure.Storage.Blob;
+using Serilog.Events;
+using Serilog.Formatting;
+using Xunit;
+
+namespace Serilog.Sinks.AzureBlobStorage.UnitTest
+{
+    public class DefaultAppendBlobBlockWriterUT
+    {
+        readonly DefaultAppendBlobBlockWriter _defaultAppendBlobBlockWriter;
+
+        readonly CloudAppendBlob _cloudBlobFake= A.Fake<CloudAppendBlob>(opt=> opt.WithArgumentsForConstructor(new[] { new Uri("https://blob.com/test/test.txt") }));
+
+        readonly IEnumerable<string> _noBlocksToWrite = Enumerable.Empty<string>();
+        readonly IEnumerable<string> _singleBlockToWrite = new[] { new string('*', 1024 * 1024 * 3) };
+        readonly IEnumerable<string> _multipleBlocksToWrite = new[] { new string('*', 1024 * 512 * 3), new string('*', 1024 * 512 * 3) };
+
+        readonly ICollection<Stream> _writtenBlocks = new List<Stream>();
+
+        public DefaultAppendBlobBlockWriterUT()
+        {
+            _defaultAppendBlobBlockWriter = new DefaultAppendBlobBlockWriter();
+        }
+
+        [Fact(DisplayName = "Should not write anything when no blocks to write.")]
+        public async Task WriteNothingIfNoBlocksSent()
+        {
+            await _defaultAppendBlobBlockWriter.WriteBlocksToAppendBlobAsync(_cloudBlobFake, _noBlocksToWrite);
+
+            A.CallTo(() => _cloudBlobFake.AppendBlockAsync(A<Stream>.Ignored, null)).MustNotHaveHappened();
+        }
+
+        [Fact(DisplayName = "Should write as many blocks as going in, one.")]
+        public async Task WriteSingleBlockOnSingleInput()
+        {
+            await _defaultAppendBlobBlockWriter.WriteBlocksToAppendBlobAsync(_cloudBlobFake, _singleBlockToWrite);
+
+            A.CallTo(() => _cloudBlobFake.AppendBlockAsync(A<Stream>.Ignored, null)).MustHaveHappenedOnceExactly();
+        }
+
+        [Fact(DisplayName = "Should write as many blocks as going in, two.")]
+        public async Task WriteTwoBlocksOnOnInputOfTwo()
+        {
+            await _defaultAppendBlobBlockWriter.WriteBlocksToAppendBlobAsync(_cloudBlobFake, _multipleBlocksToWrite);
+
+            A.CallTo(() => _cloudBlobFake.AppendBlockAsync(A<Stream>.Ignored, null)).MustHaveHappened(_multipleBlocksToWrite.Count(), Times.Exactly);
+        }
+    }
+}

--- a/tests/Serilog.Sinks.AzureBlobStorage.UnitTest/DefaultCloudBlobProviderUT.cs
+++ b/tests/Serilog.Sinks.AzureBlobStorage.UnitTest/DefaultCloudBlobProviderUT.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FakeItEasy;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Auth;
+using Microsoft.WindowsAzure.Storage.Blob;
+using Serilog.Sinks.AzureBlobStorage.AzureBlobProvider;
+using Xunit;
+
+namespace Serilog.Sinks.AzureBlobStorage.UnitTest
+{
+    public class DefaultCloudBlobProviderUT
+    {
+        readonly CloudStorageAccount _storageAccount = A.Fake<CloudStorageAccount>(opt => opt.WithArgumentsForConstructor(new object[] { new StorageCredentials(), "account", "suffix.blobs.com", true }));
+        readonly CloudBlobClient _blobClient = A.Fake<CloudBlobClient>(opt => opt.WithArgumentsForConstructor(new object[] { new Uri("https://account.suffix.blobs.com") }));
+
+        readonly string _blobContainerName = "logcontainer";
+        readonly CloudBlobContainer _blobContainer = A.Fake<CloudBlobContainer>(opt => opt.WithArgumentsForConstructor(new object[] { new Uri("https://account.suffix.blobs.com/logcontainer") }));
+
+        readonly DefaultCloudBlobProvider _defaultCloudBlobProvider = new DefaultCloudBlobProvider();
+
+
+        public DefaultCloudBlobProviderUT()
+        {
+            A.CallTo(() => _storageAccount.CreateCloudBlobClient()).Returns(_blobClient);
+            A.CallTo(() => _blobClient.GetContainerReference(_blobContainerName)).Returns(_blobContainer);
+            A.CallTo(() => _blobContainer.CreateIfNotExistsAsync()).Returns(Task.FromResult(true));
+        }
+
+        private CloudAppendBlob SetupCloudAppendBlobReference(string blobName, int blockCount)
+        {
+            CloudAppendBlob cloudAppendBlob = A.Fake<CloudAppendBlob>(opt => opt.WithArgumentsForConstructor(new object[] { new Uri("https://account.suffix.blobs.com/logcontainer/" + blobName) }));
+
+            SetCloudBlobBlockCount(cloudAppendBlob, blockCount);
+
+            A.CallTo(() => cloudAppendBlob.Name).Returns(blobName);
+            A.CallTo(() => cloudAppendBlob.CreateOrReplaceAsync(A<AccessCondition>.Ignored, null,null)).Returns(Task.FromResult(true));
+            A.CallTo(() => cloudAppendBlob.FetchAttributesAsync()).Returns(Task.FromResult(true));
+
+            A.CallTo(() => _blobContainer.GetAppendBlobReference(blobName)).Returns(cloudAppendBlob);
+
+            return cloudAppendBlob;
+        }
+
+        private void SetCloudBlobBlockCount(CloudAppendBlob cloudAppendBlob, int newBlockCount)
+        {
+            cloudAppendBlob.Properties.GetType().GetProperty(nameof(BlobProperties.AppendBlobCommittedBlockCount)).SetValue(cloudAppendBlob.Properties, newBlockCount, null);
+        }
+
+        [Fact(DisplayName = "Should return same cloudblob if blobname is unchanged and max blocks has not been reached during.")]
+        public async Task ReturnSameBlobReferenceIfNameNotChangedAndMaxBlocksNotReached()
+        {
+            string blobName = "SomeBlob.log";
+            CloudAppendBlob cloudAppendBlob = SetupCloudAppendBlobReference(blobName, 0);
+
+            CloudAppendBlob firstRequest = await _defaultCloudBlobProvider.GetCloudBlobAsync(_storageAccount, _blobContainerName, blobName, true);
+
+            //Update blockcount to a value below the max block count
+            SetCloudBlobBlockCount(firstRequest, 1000);
+
+            CloudAppendBlob secondRequest = await _defaultCloudBlobProvider.GetCloudBlobAsync(_storageAccount, _blobContainerName, blobName, true);
+
+            Assert.Same(firstRequest, secondRequest);
+        }
+
+
+        [Fact(DisplayName = "Should return a rolled cloudblob if blobname is unchanged but max blocks has been reached during.")]
+        public async Task ReturnRolledBlobReferenceIfNameNotChangedAndMaxBlocksReached()
+        {
+            string blobName = "SomeBlob.log";
+            string rolledBlobName = "SomeBlob-001.log";
+            CloudAppendBlob cloudAppendBlob = SetupCloudAppendBlobReference(blobName, 40000);
+
+            CloudAppendBlob firstRequest = await _defaultCloudBlobProvider.GetCloudBlobAsync(_storageAccount, _blobContainerName, blobName, true);
+
+            //Update blockcount to a value below the max block count
+            SetCloudBlobBlockCount(firstRequest, 50000);
+
+            //setup the rolled cloudblob
+            CloudAppendBlob rolledCloudAppendBlob = SetupCloudAppendBlobReference(rolledBlobName, 0);
+
+            CloudAppendBlob secondRequest = await _defaultCloudBlobProvider.GetCloudBlobAsync(_storageAccount, _blobContainerName, blobName, true);
+
+            Assert.NotSame(firstRequest, secondRequest);
+            Assert.Equal(blobName, firstRequest.Name);
+            Assert.Equal(rolledBlobName, secondRequest.Name);
+        }
+
+        [Fact(DisplayName = "Should return a rolled cloudblob on init if first blobs already reached the max block count.")]
+        public async Task ReturnRolledBlobReferenceOnInitIfMaxBlocksReached()
+        {
+            string blobName = "SomeBlob.log";
+            string firstRolledBlobName = "SomeBlob-001.log";
+            string secondRolledBlobName = "SomeBlob-002.log";
+            CloudAppendBlob cloudAppendBlob = SetupCloudAppendBlobReference(blobName, 50000);
+            CloudAppendBlob firstRolledCloudAppendBlob = SetupCloudAppendBlobReference(firstRolledBlobName, 50000);
+            CloudAppendBlob secondRolledcloudAppendBlob = SetupCloudAppendBlobReference(secondRolledBlobName, 10000);
+
+            CloudAppendBlob requestedBlob = await _defaultCloudBlobProvider.GetCloudBlobAsync(_storageAccount, _blobContainerName, blobName, true);
+
+            Assert.Equal(secondRolledBlobName, requestedBlob.Name);
+        }
+
+        [Fact(DisplayName = "Should throw exception if container cannot be created and bypass is false.")]
+        public async Task ThrowExceptionIfContainerCannotBeCreatedAndNoBypass()
+        {
+            string blobName = "SomeBlob.log";
+            CloudAppendBlob cloudAppendBlob = SetupCloudAppendBlobReference(blobName, 1000);
+
+            A.CallTo(() => _blobContainer.CreateIfNotExistsAsync()).Invokes(() => throw new StorageException());
+
+            await Assert.ThrowsAnyAsync<Exception>(() => _defaultCloudBlobProvider.GetCloudBlobAsync(_storageAccount, _blobContainerName, blobName, false));
+        }
+
+        [Fact(DisplayName = "Should not throw exception if container cannot be 'CreatedIfNotExists' and bypass is true.")]
+        public async Task DoNoThrowExceptionIfContainerCannotBeCreatedAndBypass()
+        {
+            string blobName = "SomeBlob.log";
+            CloudAppendBlob cloudAppendBlob = SetupCloudAppendBlobReference(blobName, 1000);
+
+            A.CallTo(() => _blobContainer.CreateIfNotExistsAsync()).Invokes(() => throw new StorageException());
+
+            CloudAppendBlob blob = await _defaultCloudBlobProvider.GetCloudBlobAsync(_storageAccount, _blobContainerName, blobName, true);
+        }
+
+        [Fact(DisplayName = "Should throw exception if container cannot be 'CreatedIfNotExists' and bypass is true and container really does not exist.")]
+        public async Task ThrowExceptionIfContainerCannotBeCreatedAndBypassAndContainerDoesNotExist()
+        {
+
+            A.CallTo(() => _blobContainer.CreateIfNotExistsAsync()).Invokes(() => throw new StorageException());
+
+            string blobName = "SomeBlob.log";
+            CloudAppendBlob cloudAppendBlob = SetupCloudAppendBlobReference(blobName, 1000);
+            A.CallTo(() => cloudAppendBlob.CreateOrReplaceAsync(A<AccessCondition>.Ignored, null, null)).Invokes(() => throw new StorageException());
+
+            await Assert.ThrowsAnyAsync<Exception>(() => _defaultCloudBlobProvider.GetCloudBlobAsync(_storageAccount, _blobContainerName, blobName, true));
+        }
+    }
+}

--- a/tests/Serilog.Sinks.AzureBlobStorage.UnitTest/DefaultCloudBlobProviderUT.cs
+++ b/tests/Serilog.Sinks.AzureBlobStorage.UnitTest/DefaultCloudBlobProviderUT.cs
@@ -104,6 +104,24 @@ namespace Serilog.Sinks.AzureBlobStorage.UnitTest
             Assert.Equal(secondRolledBlobName, requestedBlob.Name);
         }
 
+        [Fact(DisplayName = "Should return a new cloudblob non-rolled, if previous cloudblob was rolled.")]
+        public async Task ReturnNonRolledBlobReferenceOnInitIfPreviousCloudblobWasRolled()
+        {
+            string blobName = "SomeBlob.log";
+            string rolledBlobName = "SomeBlob-001.log";
+            string newBlobName = "SomeNewBlob.log";
+
+            CloudAppendBlob cloudAppendBlob = SetupCloudAppendBlobReference(blobName, 50000);
+            CloudAppendBlob firstRolledCloudAppendBlob = SetupCloudAppendBlobReference(rolledBlobName, 40000);
+            CloudAppendBlob newCloudAppendBlob = SetupCloudAppendBlobReference(newBlobName, 0);
+
+            CloudAppendBlob requestedBlob = await _defaultCloudBlobProvider.GetCloudBlobAsync(_storageAccount, _blobContainerName, blobName, true);
+            CloudAppendBlob requestednewBlob = await _defaultCloudBlobProvider.GetCloudBlobAsync(_storageAccount, _blobContainerName, newBlobName, true);
+
+            Assert.Equal(rolledBlobName, requestedBlob.Name);
+            Assert.Equal(newBlobName, requestednewBlob.Name);
+        }
+
         [Fact(DisplayName = "Should throw exception if container cannot be created and bypass is false.")]
         public async Task ThrowExceptionIfContainerCannotBeCreatedAndNoBypass()
         {

--- a/tests/Serilog.Sinks.AzureBlobStorage.UnitTest/Serilog.Sinks.AzureBlobStorage.UnitTest.csproj
+++ b/tests/Serilog.Sinks.AzureBlobStorage.UnitTest/Serilog.Sinks.AzureBlobStorage.UnitTest.csproj
@@ -1,13 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Azurite" Version="2.6.5" />
+    <PackageReference Include="FakeItEasy" Version="5.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Serilog" Version="2.6.0" />
     <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.1.1" />


### PR DESCRIPTION
Fixed some bugs in the DefaultCloudBlobProvider and enhanced it with rolling on reaching the max number of blocks. Which is a potential problem in production systems with small batch sizes and lots of logging.Unit tests are included.

Created a new class DefaultAppendBlobPreparer that takes the logevents to write and creates one or more blocks that stay within the 4MB limit that Azure Storage imposes. Unit tests are included.

Created a new class DefaultAppendBlobWriter that takes care of writing the blocks to the appendblob. Extracted that logic from the sink itself. The sinks themselves are now very simple and clean. Unit tests are included.

Fixed a small issue in the LoggerConfigurationAzureBlobStorageExtensions class. Where the blob endpoint was written into the tablestorage endpoint if provided. That would limit the usage of this sink to Azure Cloud and exclude Azure China, Azure Gov, Azure Germany etc.