### PR TITLE
fix: Update to use latest Serilog libraries

### DIFF
--- a/src/Serilog.Sinks.AzureBlobStorage/Serilog.Sinks.AzureBlobStorage.csproj
+++ b/src/Serilog.Sinks.AzureBlobStorage/Serilog.Sinks.AzureBlobStorage.csproj
@@ -4,7 +4,7 @@
     <Description>Serilog event sink that writes to Azure Blob Storage over HTTP.</Description>
     <VersionPrefix>1.0.0</VersionPrefix>
     <Authors>Chris Williams and Serilog.Sinks.AzureBlobStorage contributors</Authors>
-    <TargetFrameworks>netstandard1.3;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;net452;netstandard2.0;</TargetFrameworks>
     <AssemblyName>Serilog.Sinks.AzureBlobStorage</AssemblyName>            
     <RootNamespace>Serilog</RootNamespace>
     <PackageId>Serilog.Sinks.AzureBlobStorage</PackageId>
@@ -25,9 +25,9 @@
   </PropertyGroup>
 
   <ItemGroup>    
-    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="10.0.0" />        
-    <PackageReference Include="Serilog" Version="2.7.1" />
-    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="10.0.3" />        
+    <PackageReference Include="Serilog" Version="2.8.0" />
+    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Serilog.Sinks.AzureBlobStorage.UnitTest/Serilog.Sinks.AzureBlobStorage.UnitTest.csproj
+++ b/tests/Serilog.Sinks.AzureBlobStorage.UnitTest/Serilog.Sinks.AzureBlobStorage.UnitTest.csproj
@@ -8,8 +8,8 @@
   <ItemGroup>    
     <PackageReference Include="FakeItEasy" Version="5.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-    <PackageReference Include="Serilog" Version="2.7.1" />
-    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.1.1" />
+    <PackageReference Include="Serilog" Version="2.8.0" />
+    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
fix: Update to use latest Serilog libraries and support .NET Standard 2.0.  Should fix issues  #35, #36