### PR TITLE
Add 'retainedBlobCountLimit'(option) to limit the number of blobs retained in a container

### DIFF
--- a/src/Serilog.Sinks.AzureBlobStorage/LoggerConfigurationAzureBlobStorageExtensions.cs
+++ b/src/Serilog.Sinks.AzureBlobStorage/LoggerConfigurationAzureBlobStorageExtensions.cs
@@ -63,6 +63,7 @@ namespace Serilog
         /// <param name="bypassBlobCreationValidation">Bypass the exception in case the blob creation fails.</param>
         /// <param name="cloudBlobProvider">Cloud Blob provider to get current log blob.</param>
         /// <param name="blobSizeLimitBytes">The maximum file size to allow before a new one is rolled, expressed in bytes.</param>
+        /// <param name="retainedBlobCountLimit">The number of latest blobs to be retained in the container always. Deletes older blobs when this limit is crossed.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration AzureBlobStorage(
@@ -78,7 +79,8 @@ namespace Serilog
             bool bypassBlobCreationValidation = false,
             IFormatProvider formatProvider = null,
             ICloudBlobProvider cloudBlobProvider = null,
-            long? blobSizeLimitBytes = null)
+            long? blobSizeLimitBytes = null,
+            int? retainedBlobCountLimit = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
             if (storageAccount == null) throw new ArgumentNullException(nameof(storageAccount));
@@ -100,7 +102,8 @@ namespace Serilog
                 batchPostingLimit,
                 bypassBlobCreationValidation,
                 cloudBlobProvider,
-                blobSizeLimitBytes);
+                blobSizeLimitBytes,
+                retainedBlobCountLimit);
         }
 
         /// <summary>
@@ -119,7 +122,8 @@ namespace Serilog
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="bypassBlobCreationValidation">Bypass the exception in case the blob creation fails.</param>
         /// <param name="cloudBlobProvider">Cloud blob provider to get current log blob.</param>
-        /// <param name="blobSizeLimitBytes">The maximum file size to allow before a new one is rolled, expressed in bytes.</param> 
+        /// <param name="blobSizeLimitBytes">The maximum file size to allow before a new one is rolled, expressed in bytes.</param>
+        /// <param name="retainedBlobCountLimit">The number of latest blobs to be retained in the container always. Deletes older blobs when this limit is crossed.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration AzureBlobStorage(
@@ -135,7 +139,8 @@ namespace Serilog
             bool bypassBlobCreationValidation = false,
             IFormatProvider formatProvider = null,
             ICloudBlobProvider cloudBlobProvider = null,
-            long? blobSizeLimitBytes = null)
+            long? blobSizeLimitBytes = null,
+            int? retainedBlobCountLimit = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
             if (string.IsNullOrEmpty(connectionString)) throw new ArgumentNullException(nameof(connectionString));
@@ -157,7 +162,8 @@ namespace Serilog
                 batchPostingLimit,
                 bypassBlobCreationValidation,
                 cloudBlobProvider,
-                blobSizeLimitBytes);
+                blobSizeLimitBytes,
+                retainedBlobCountLimit);
         }
 
         /// <summary>
@@ -178,7 +184,8 @@ namespace Serilog
         /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="cloudBlobProvider">Cloud blob provider to get current log blob.</param>
-        /// <param name="blobSizeLimitBytes">The maximum file size to allow before a new one is rolled, expressed in bytes.</param> 
+        /// <param name="blobSizeLimitBytes">The maximum file size to allow before a new one is rolled, expressed in bytes.</param>
+        /// <param name="retainedBlobCountLimit">The number of latest blobs to be retained in the container always. Deletes older blobs when this limit is crossed.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration AzureBlobStorage(
@@ -195,7 +202,8 @@ namespace Serilog
             int? batchPostingLimit = null,
             IFormatProvider formatProvider = null,
             ICloudBlobProvider cloudBlobProvider = null,
-            long? blobSizeLimitBytes = null)
+            long? blobSizeLimitBytes = null,
+            int? retainedBlobCountLimit = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
             if (string.IsNullOrWhiteSpace(accountName)) throw new ArgumentNullException(nameof(accountName));
@@ -220,7 +228,8 @@ namespace Serilog
                 period,
                 batchPostingLimit,
                 cloudBlobProvider,
-                blobSizeLimitBytes);
+                blobSizeLimitBytes,
+                retainedBlobCountLimit);
         }
 
         /// <summary>
@@ -238,7 +247,8 @@ namespace Serilog
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="bypassBlobCreationValidation">Bypass the exception in case the blob creation fails.</param>
         /// <param name="cloudBlobProvider">Cloud blob provider to get current log blob.</param>
-        /// <param name="blobSizeLimitBytes">The maximum file size to allow before a new one is rolled, expressed in bytes.</param> 
+        /// <param name="blobSizeLimitBytes">The maximum file size to allow before a new one is rolled, expressed in bytes.</param>
+        /// <param name="retainedBlobCountLimit">The number of latest blobs to be retained in the container always. Deletes older blobs when this limit is crossed.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration AzureBlobStorage(
@@ -253,19 +263,21 @@ namespace Serilog
             int? batchPostingLimit = null,
             bool bypassBlobCreationValidation = false,
             ICloudBlobProvider cloudBlobProvider = null,
-            long? blobSizeLimitBytes = null)
+            long? blobSizeLimitBytes = null,
+            int? retainedBlobCountLimit = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
             if (formatter == null) throw new ArgumentNullException(nameof(formatter));
             if (storageAccount == null) throw new ArgumentNullException(nameof(storageAccount));
             if (blobSizeLimitBytes != null && blobSizeLimitBytes < 1) throw new ArgumentException("Invalid value provided; file size limit must be at least 1 byte, or null.");
+            if (retainedBlobCountLimit != null && retainedBlobCountLimit < 1) throw new ArgumentException("Invalid value provided; retained blob count limit must be at least 1 or null.");
 
             ILogEventSink sink;
             try
             {
                 sink = writeInBatches ?
-                    (ILogEventSink)new AzureBatchingBlobStorageSink(storageAccount.CreateCloudBlobClient(), formatter, batchPostingLimit ?? DefaultBatchPostingLimit, period ?? DefaultPeriod, storageContainerName, storageFileName, bypassBlobCreationValidation, cloudBlobProvider, blobSizeLimitBytes: blobSizeLimitBytes) :
-                    new AzureBlobStorageSink(storageAccount.CreateCloudBlobClient(), formatter, storageContainerName, storageFileName, bypassBlobCreationValidation, cloudBlobProvider, blobSizeLimitBytes: blobSizeLimitBytes);
+                    (ILogEventSink)new AzureBatchingBlobStorageSink(storageAccount.CreateCloudBlobClient(), formatter, batchPostingLimit ?? DefaultBatchPostingLimit, period ?? DefaultPeriod, storageContainerName, storageFileName, bypassBlobCreationValidation, cloudBlobProvider, blobSizeLimitBytes: blobSizeLimitBytes, retainedBlobCountLimit: retainedBlobCountLimit) :
+                    new AzureBlobStorageSink(storageAccount.CreateCloudBlobClient(), formatter, storageContainerName, storageFileName, bypassBlobCreationValidation, cloudBlobProvider, blobSizeLimitBytes: blobSizeLimitBytes, retainedBlobCountLimit: retainedBlobCountLimit);
             }
             catch (Exception ex)
             {
@@ -292,7 +304,8 @@ namespace Serilog
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="bypassBlobCreationValidation">Bypass the exception in case the blob creation fails.</param>
         /// <param name="cloudBlobProvider">Cloud blob provider to get current log blob.</param>
-        /// <param name="blobSizeLimitBytes">The maximum file size to allow before a new one is rolled, expressed in bytes.</param> 
+        /// <param name="blobSizeLimitBytes">The maximum file size to allow before a new one is rolled, expressed in bytes.</param>
+        /// <param name="retainedBlobCountLimit">The number of latest blobs to be retained in the container always. Deletes older blobs when this limit is crossed.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration AzureBlobStorage(
@@ -307,7 +320,8 @@ namespace Serilog
             int? batchPostingLimit = null,
             bool bypassBlobCreationValidation = false,
             ICloudBlobProvider cloudBlobProvider = null,
-            long? blobSizeLimitBytes = null)
+            long? blobSizeLimitBytes = null,
+            int? retainedBlobCountLimit = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
             if (formatter == null) throw new ArgumentNullException(nameof(formatter));
@@ -317,7 +331,7 @@ namespace Serilog
             {
                 var storageAccount = CloudStorageAccount.Parse(connectionString);
                 
-                return AzureBlobStorage(loggerConfiguration, formatter, storageAccount, restrictedToMinimumLevel, storageContainerName, storageFileName, writeInBatches, period, batchPostingLimit, bypassBlobCreationValidation, cloudBlobProvider, blobSizeLimitBytes);
+                return AzureBlobStorage(loggerConfiguration, formatter, storageAccount, restrictedToMinimumLevel, storageContainerName, storageFileName, writeInBatches, period, batchPostingLimit, bypassBlobCreationValidation, cloudBlobProvider, blobSizeLimitBytes, retainedBlobCountLimit);
             }
             catch (Exception ex)
             {
@@ -345,7 +359,8 @@ namespace Serilog
         /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="cloudBlobProvider">Cloud blob provider to get current log blob.</param>
-        /// <param name="blobSizeLimitBytes">The maximum file size to allow before a new one is rolled, expressed in bytes.</param> 
+        /// <param name="blobSizeLimitBytes">The maximum file size to allow before a new one is rolled, expressed in bytes.</param>
+        /// <param name="retainedBlobCountLimit">The number of latest blobs to be retained in the container always. Deletes older blobs when this limit is crossed.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration AzureBlobStorage(
@@ -361,7 +376,8 @@ namespace Serilog
             TimeSpan? period = null,
             int? batchPostingLimit = null,
             ICloudBlobProvider cloudBlobProvider = null,
-            long? blobSizeLimitBytes = null)
+            long? blobSizeLimitBytes = null,
+            int? retainedBlobCountLimit = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
             if (formatter == null) throw new ArgumentNullException(nameof(formatter));
@@ -382,7 +398,7 @@ namespace Serilog
                 }
 
                 // We set bypassBlobCreationValidation to true explicitly here as the the SAS URL might not have enough permissions to query if the blob exists.
-                return AzureBlobStorage(loggerConfiguration, formatter, storageAccount, restrictedToMinimumLevel, storageContainerName, storageFileName, writeInBatches, period, batchPostingLimit, true, cloudBlobProvider, blobSizeLimitBytes);
+                return AzureBlobStorage(loggerConfiguration, formatter, storageAccount, restrictedToMinimumLevel, storageContainerName, storageFileName, writeInBatches, period, batchPostingLimit, true, cloudBlobProvider, blobSizeLimitBytes, retainedBlobCountLimit);
             }
             catch (Exception ex)
             {

--- a/src/Serilog.Sinks.AzureBlobStorage/Sinks/AzureBlobProvider/DefaultCloudBlobProvider.cs
+++ b/src/Serilog.Sinks.AzureBlobStorage/Sinks/AzureBlobProvider/DefaultCloudBlobProvider.cs
@@ -14,7 +14,10 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using Microsoft.Azure.Storage;
@@ -142,6 +145,40 @@ namespace Serilog.Sinks.AzureBlobStorage.AzureBlobProvider
                 {
                     throw;
                 }
+            }
+        }
+
+        public async Task DeleteArchivedBlobsAsync(CloudBlobClient cloudBlobClient, string blobContainerName, string blobNameFormat, int retainedBlobCountLimit)
+        {
+            if(retainedBlobCountLimit < 1)
+            {
+                throw new ArgumentException("Invalid value provided; retained blob count limit must be at least 1 or null.");
+            }
+
+            CloudBlobContainer cloudBlobContainer = cloudBlobClient.GetContainerReference(blobContainerName);
+            BlobContinuationToken blobContinuationToken = null;
+            List<IListBlobItem> logBlobs = new List<IListBlobItem>();
+            do
+            {
+                var results = await cloudBlobContainer.ListBlobsSegmentedAsync(null, true, BlobListingDetails.None, null, blobContinuationToken, null, null);
+                // Get the value of the continuation token returned by the listing call.
+                blobContinuationToken = results.ContinuationToken;
+                logBlobs.AddRange(results.Results);                
+            } while (blobContinuationToken != null);
+
+            var validLogBlobs = logBlobs.Where(blobItem => {
+                return DateTime.TryParseExact(new CloudAppendBlob(blobItem.Uri).Name, 
+                    blobNameFormat, 
+                    CultureInfo.InvariantCulture, 
+                    DateTimeStyles.AssumeLocal, 
+                    out var _date);
+            });
+
+            var blobsToDelete = validLogBlobs.OrderByDescending(blob => new CloudAppendBlob(blob.Uri).Name).Skip(retainedBlobCountLimit);
+            foreach (IListBlobItem blob in blobsToDelete)
+            {
+                var blobToDelete = cloudBlobContainer.GetBlobReference(new CloudAppendBlob(blob.Uri).Name);
+                await blobToDelete.DeleteIfExistsAsync();
             }
         }
     }

--- a/src/Serilog.Sinks.AzureBlobStorage/Sinks/AzureBlobProvider/ICloudBlobProvider.cs
+++ b/src/Serilog.Sinks.AzureBlobStorage/Sinks/AzureBlobProvider/ICloudBlobProvider.cs
@@ -21,5 +21,6 @@ namespace Serilog.Sinks.AzureBlobStorage.AzureBlobProvider
     public interface ICloudBlobProvider
     {
         Task<CloudAppendBlob> GetCloudBlobAsync(CloudBlobClient cloudBlobClient, string blobContainerName, string blobName, bool bypassBlobCreationValidation, long? blobSizeLimitBytes = null);
+        Task DeleteArchivedBlobsAsync(CloudBlobClient cloudBlobClient, string blobContainerName, string blobNameFormat, int retainedBlobCountLimit);
     }
 }

--- a/src/Serilog.Sinks.AzureBlobStorage/Sinks/AzureBlobStorage/AzureBatchingBlobStorageSink.cs
+++ b/src/Serilog.Sinks.AzureBlobStorage/Sinks/AzureBlobStorage/AzureBatchingBlobStorageSink.cs
@@ -133,14 +133,14 @@ namespace Serilog.Sinks.AzureBlobStorage
             if (lastEvent == null)
                 return;
 
-            if(retainedBlobCountLimit != null)
-                await cloudBlobProvider.DeleteArchivedBlobsAsync(cloudBlobClient, storageContainerName, blobNameFactory.GetBlobNameFormat(), retainedBlobCountLimit ?? default(int));
-
             var blob = await cloudBlobProvider.GetCloudBlobAsync(cloudBlobClient, storageContainerName, blobNameFactory.GetBlobName(lastEvent.Timestamp), bypassBlobCreationValidation, blobSizeLimitBytes).ConfigureAwait(false);
 
             var blocks = appendBlobBlockPreparer.PrepareAppendBlocks(textFormatter, events);
 
             await appendBlobBlockWriter.WriteBlocksToAppendBlobAsync(blob, blocks).ConfigureAwait(false);
+
+            if (retainedBlobCountLimit != null)
+                await cloudBlobProvider.DeleteArchivedBlobsAsync(cloudBlobClient, storageContainerName, blobNameFactory.GetBlobNameFormat(), retainedBlobCountLimit ?? default(int));
         }
     }
 }

--- a/src/Serilog.Sinks.AzureBlobStorage/Sinks/AzureBlobStorage/AzureBlobStorageSink.cs
+++ b/src/Serilog.Sinks.AzureBlobStorage/Sinks/AzureBlobStorage/AzureBlobStorageSink.cs
@@ -94,14 +94,14 @@ namespace Serilog.Sinks.AzureBlobStorage
         /// <param name="logEvent">The log event to write.</param>
         public void Emit(LogEvent logEvent)
         {
-            if (retainedBlobCountLimit != null)
-                cloudBlobProvider.DeleteArchivedBlobsAsync(cloudBlobClient, storageContainerName, blobNameFactory.GetBlobNameFormat(), retainedBlobCountLimit ?? default(int));
-
             var blob = cloudBlobProvider.GetCloudBlobAsync(cloudBlobClient, storageContainerName, blobNameFactory.GetBlobName(logEvent.Timestamp), bypassContainerCreationValidation, blobSizeLimitBytes: blobSizeLimitBytes).SyncContextSafeWait(waitTimeoutMilliseconds);
 
             var blocks = appendBlobBlockPreparer.PrepareAppendBlocks(textFormatter, new[] { logEvent });
 
             appendBlobBlockWriter.WriteBlocksToAppendBlobAsync(blob, blocks).SyncContextSafeWait(waitTimeoutMilliseconds);
+
+            if (retainedBlobCountLimit != null)
+                cloudBlobProvider.DeleteArchivedBlobsAsync(cloudBlobClient, storageContainerName, blobNameFactory.GetBlobNameFormat(), retainedBlobCountLimit ?? default(int));
         }
     }
 }

--- a/src/Serilog.Sinks.AzureBlobStorage/Sinks/AzureBlobStorage/AzureBlobStorageSink.cs
+++ b/src/Serilog.Sinks.AzureBlobStorage/Sinks/AzureBlobStorage/AzureBlobStorageSink.cs
@@ -38,6 +38,7 @@ namespace Serilog.Sinks.AzureBlobStorage
         private readonly IAppendBlobBlockWriter appendBlobBlockWriter;
         private readonly BlobNameFactory blobNameFactory;
         private readonly long? blobSizeLimitBytes;
+        private readonly int? retainedBlobCountLimit;
 
         /// <summary>
         /// Construct a sink that saves logs to the specified storage account.
@@ -51,6 +52,7 @@ namespace Serilog.Sinks.AzureBlobStorage
         /// <param name="appendBlobBlockPreparer"></param>
         /// <param name="appendBlobBlockWriter"></param>
         /// <param name="blobSizeLimitBytes">The maximum file size to allow before a new one is rolled, expressed in bytes.</param>  
+        /// <param name="retainedBlobCountLimit">The number of latest blobs to be retained in the container always. Deletes older blobs when this limit is crossed.</param>
         public AzureBlobStorageSink(
             CloudBlobClient cloudBlobClient,
             ITextFormatter textFormatter,
@@ -60,7 +62,8 @@ namespace Serilog.Sinks.AzureBlobStorage
             ICloudBlobProvider cloudBlobProvider = null,
             IAppendBlobBlockPreparer appendBlobBlockPreparer = null,
             IAppendBlobBlockWriter appendBlobBlockWriter = null,
-            long? blobSizeLimitBytes = null)
+            long? blobSizeLimitBytes = null,
+            int? retainedBlobCountLimit = null)
         {
             this.textFormatter = textFormatter;
 
@@ -82,6 +85,7 @@ namespace Serilog.Sinks.AzureBlobStorage
             this.appendBlobBlockPreparer = appendBlobBlockPreparer ?? new DefaultAppendBlobBlockPreparer();
             this.appendBlobBlockWriter = appendBlobBlockWriter ?? new DefaultAppendBlobBlockWriter();
             this.blobSizeLimitBytes = blobSizeLimitBytes;
+            this.retainedBlobCountLimit = retainedBlobCountLimit;
         }
 
         /// <summary>
@@ -90,6 +94,9 @@ namespace Serilog.Sinks.AzureBlobStorage
         /// <param name="logEvent">The log event to write.</param>
         public void Emit(LogEvent logEvent)
         {
+            if (retainedBlobCountLimit != null)
+                cloudBlobProvider.DeleteArchivedBlobsAsync(cloudBlobClient, storageContainerName, blobNameFactory.GetBlobNameFormat(), retainedBlobCountLimit ?? default(int));
+
             var blob = cloudBlobProvider.GetCloudBlobAsync(cloudBlobClient, storageContainerName, blobNameFactory.GetBlobName(logEvent.Timestamp), bypassContainerCreationValidation, blobSizeLimitBytes: blobSizeLimitBytes).SyncContextSafeWait(waitTimeoutMilliseconds);
 
             var blocks = appendBlobBlockPreparer.PrepareAppendBlocks(textFormatter, new[] { logEvent });

--- a/src/Serilog.Sinks.AzureBlobStorage/Sinks/AzureBlobStorage/BlobNameFactory.cs
+++ b/src/Serilog.Sinks.AzureBlobStorage/Sinks/AzureBlobStorage/BlobNameFactory.cs
@@ -79,6 +79,11 @@ namespace Serilog.Sinks.AzureBlobStorage
             }
         }
 
+        /// <summary>
+        /// Gets a blob name format (parsable by DateTime) generated based on the blob name passed to the logger, 
+        /// to identify the blobs in the container created by the logger 
+        /// and only consider those while counting for deletion of older blobs.
+        /// </summary>
         public string GetBlobNameFormat()
         {
             // Create copy of the base name

--- a/src/Serilog.Sinks.AzureBlobStorage/Sinks/AzureBlobStorage/BlobNameFactory.cs
+++ b/src/Serilog.Sinks.AzureBlobStorage/Sinks/AzureBlobStorage/BlobNameFactory.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace Serilog.Sinks.AzureBlobStorage
 {
@@ -75,6 +77,39 @@ namespace Serilog.Sinks.AzureBlobStorage
 
                 i = closeBraceIndex + 1;
             }
+        }
+
+        public string GetBlobNameFormat()
+        {
+            // Create copy of the base name
+            string defaultName = (string)baseBlobName.Clone();
+            string pattern = "{(.*?)}";
+
+            // get all words between curly braces ({<date time format>})
+            var dateFormats = Regex.Matches(defaultName, pattern)
+                .Cast<Match>()
+                .Select(m => m.Groups[1].Value)
+                .ToArray();
+
+            // gets all dateformat strings and non-dateformat strings
+            string[] fileNameSplit = Regex.Split(defaultName, pattern);
+
+            List<string> fileNameParts = new List<string>();
+            // For all "non-dateformat" strings, it encloses in a single-quotes as a string literal
+            foreach (var fileNamePart in fileNameSplit)
+            {
+                if (dateFormats.Contains(fileNamePart))
+                {
+                    fileNameParts.Add(fileNamePart);
+                }
+                else
+                {
+                    fileNameParts.Add("'" + fileNamePart + "'");
+                }
+            }
+
+            string fileFormatRegex = String.Join("", fileNameParts.ToArray());
+            return fileFormatRegex;
         }
     }
 }

--- a/tests/Serilog.Sinks.AzureBlobStorage.UnitTest/BlobNameFactoryUT.cs
+++ b/tests/Serilog.Sinks.AzureBlobStorage.UnitTest/BlobNameFactoryUT.cs
@@ -101,5 +101,23 @@ namespace Serilog.Sinks.AzureBlobStorage.UnitTest
 
             Assert.Equal("webhook/2018/11/05/logs-2018-11-05.txt", result);
         }
+
+        [Theory(DisplayName = "Returns the blob name format which is supported by DateTime Parser to identify blobs created by the logger.")]
+        [InlineData("{yyyy}/{dd}/{MM}/name.txt", "''yyyy'/'dd'/'MM'/name.txt'")]
+        [InlineData("samename.txt", "'samename.txt'")]
+        [InlineData("webhook/{yyyy}/{MM}/{dd}.txt", "'webhook/'yyyy'/'MM'/'dd'.txt'")]
+        [InlineData("webhook/{yyyy}/{MM}/{dd}/{HH}.txt", "'webhook/'yyyy'/'MM'/'dd'/'HH'.txt'")]
+        [InlineData("webhook/{yyyy}/{MM}/{dd}/{HH}/{mm}.txt", "'webhook/'yyyy'/'MM'/'dd'/'HH'/'mm'.txt'")]
+        [InlineData("webhook/{yyyyMMdd}/{HH}.txt", "'webhook/'yyyyMMdd'/'HH'.txt'")]
+        [InlineData("webhook/{yyyy}/{MM}/{dd}/logs.txt", "'webhook/'yyyy'/'MM'/'dd'/logs.txt'")]
+        [InlineData("webhook/{yyyy}/{MM}/{dd}/logs-{yyyy}-{MM}-{dd}.txt", "'webhook/'yyyy'/'MM'/'dd'/logs-'yyyy'-'MM'-'dd'.txt'")]
+        [InlineData("{yyyy}/{dd}/{MM}/application logs.txt", "''yyyy'/'dd'/'MM'/application logs.txt'")]
+        public void GetBlobNameFormat_ReturnsBlobNameFormatAsPerDateTimeParser(string blobName, string expectedResult)
+        {
+            var blobNameFactory = new BlobNameFactory(blobName);
+            var actualResult = blobNameFactory.GetBlobNameFormat();
+
+            Assert.Equal(expectedResult, actualResult);
+        }
     }
 }


### PR DESCRIPTION
## Brief Description 
These PR changes will enable an option called `retainedBlobCountLimit` for users to limit the number of rolling blobs in the container. It'll help delete older blobs once this threshold is crossed. The idea for this option is inspired from the [FileSink ](https://github.com/serilog/serilog-sinks-file#rolling-policies)for Serilog.

## Use Case
Maintain log blobs for last 1 week/month only and clean the older blobs which may be currently a manual process/using time-triggered Azure functions to clean the container.

## Existing Unit test results (ran locally)
![image](https://user-images.githubusercontent.com/7644629/100797467-2f40d600-3448-11eb-8b54-cd9731bcf7cb.png)

## Pending Changes
- [x] Add unit tests for the new code. [**WIP**]

Please feel free to suggest code improvements. Thanks!