### PR TITLE
Add SyncContextSafeWait to DeleteArchivedBlobsAsyn

### DIFF
--- a/src/Serilog.Sinks.AzureBlobStorage/Sinks/AzureBlobStorage/AzureBlobStorageSink.cs
+++ b/src/Serilog.Sinks.AzureBlobStorage/Sinks/AzureBlobStorage/AzureBlobStorageSink.cs
@@ -101,7 +101,7 @@ namespace Serilog.Sinks.AzureBlobStorage
             appendBlobBlockWriter.WriteBlocksToAppendBlobAsync(blob, blocks).SyncContextSafeWait(waitTimeoutMilliseconds);
 
             if (retainedBlobCountLimit != null)
-                cloudBlobProvider.DeleteArchivedBlobsAsync(cloudBlobClient, storageContainerName, blobNameFactory.GetBlobNameFormat(), retainedBlobCountLimit ?? default(int));
+                cloudBlobProvider.DeleteArchivedBlobsAsync(cloudBlobClient, storageContainerName, blobNameFactory.GetBlobNameFormat(), retainedBlobCountLimit ?? default(int)).SyncContextSafeWait(waitTimeoutMilliseconds);
         }
     }
 }


### PR DESCRIPTION
DeleteArchivedBlobsAsync is an awaitable, so shouldn;t it use SyncContextSafeWait?  This could be causing lockups.