### PR TITLE
Adding multi tenant support

### DIFF
--- a/src/Serilog.Sinks.AzureBlobStorage/Serilog.Sinks.AzureBlobStorage.csproj
+++ b/src/Serilog.Sinks.AzureBlobStorage/Serilog.Sinks.AzureBlobStorage.csproj
@@ -1,28 +1,28 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <Description>Serilog event sink that writes to Azure Blob Storage over HTTP.</Description>
-    <Authors>Chris Williams and Serilog.Sinks.AzureBlobStorage contributors</Authors>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyName>Serilog.Sinks.AzureBlobStorage</AssemblyName>            
-    <RootNamespace>Serilog</RootNamespace>
-    <PackageId>Serilog.Sinks.AzureBlobStorage</PackageId>
-    <PackageTags>serilog;logging;azure</PackageTags>
-    <PackageIconUrl></PackageIconUrl>
-    <PackageProjectUrl>https://github.com/chriswill/serilog-sinks-azureblobstorage</PackageProjectUrl>
-    <PackageLicenseUrl></PackageLicenseUrl>
-    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
-    <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-    <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Company>CloudTools, LLC</Company>
-    <Version>1.1.0</Version>
-    <RepositoryUrl>https://github.com/chriswill/serilog-sinks-azureblobstorage</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageIcon>serilog-sink-nuget.png</PackageIcon>
-  </PropertyGroup>
+	<PropertyGroup>
+		<Description>Serilog event sink that writes to Azure Blob Storage over HTTP.</Description>
+		<Authors>Chris Williams and Serilog.Sinks.AzureBlobStorage contributors</Authors>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<AssemblyName>Serilog.Sinks.AzureBlobStorage</AssemblyName>
+		<RootNamespace>Serilog</RootNamespace>
+		<PackageId>Serilog.Sinks.AzureBlobStorage</PackageId>
+		<PackageTags>serilog;logging;azure</PackageTags>
+		<PackageIconUrl></PackageIconUrl>
+		<PackageProjectUrl>https://github.com/chriswill/serilog-sinks-azureblobstorage</PackageProjectUrl>
+		<PackageLicenseUrl></PackageLicenseUrl>
+		<GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
+		<GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
+		<GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+		<Company>CloudTools, LLC</Company>
+		<Version>1.1.0</Version>
+		<RepositoryUrl>https://github.com/chriswill/serilog-sinks-azureblobstorage</RepositoryUrl>
+		<RepositoryType>git</RepositoryType>
+		<PackageLicenseFile>LICENSE.md</PackageLicenseFile>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<PackageIcon>serilog-sink-nuget.png</PackageIcon>
+	</PropertyGroup>
 
 	<ItemGroup>
 		<None Include="../../LICENSE.md" Pack="true" PackagePath="/" />
@@ -31,17 +31,17 @@
 	<ItemGroup>
 		<None Include="../../README.md" Pack="true" PackagePath="/" />
 		<None Include="..\..\serilog-sink-nuget.png">
-		  <Pack>True</Pack>
-		  <PackagePath>\</PackagePath>
+			<Pack>True</Pack>
+			<PackagePath>\</PackagePath>
 		</None>
 	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.5.0" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />        
-    <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.3.1" />
-  </ItemGroup>
- 
+	<ItemGroup>
+		<PackageReference Include="Azure.Identity" Version="1.5.0" />
+		<PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+		<PackageReference Include="Serilog" Version="2.10.0" />
+		<PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="3.1.0" />
+	</ItemGroup>
+
 </Project>

--- a/src/Serilog.Sinks.AzureBlobStorage/Sinks/AzureBlobStorage/AzureBlobStorageSink.cs
+++ b/src/Serilog.Sinks.AzureBlobStorage/Sinks/AzureBlobStorage/AzureBlobStorageSink.cs
@@ -100,7 +100,7 @@ namespace Serilog.Sinks.AzureBlobStorage
         /// <param name="logEvent">The log event to write.</param>
         public void Emit(LogEvent logEvent)
         {
-            AppendBlobClient blob = cloudBlobProvider.GetCloudBlobAsync(blobServiceClient, storageContainerName, blobNameFactory.GetBlobName(logEvent.Timestamp, useUTCTimezone), bypassContainerCreationValidation, blobSizeLimitBytes: blobSizeLimitBytes).SyncContextSafeWait(waitTimeoutMilliseconds);
+            AppendBlobClient blob = cloudBlobProvider.GetCloudBlobAsync(blobServiceClient, storageContainerName, blobNameFactory.GetBlobName(logEvent.Timestamp, logEvent.Properties, useUTCTimezone), bypassContainerCreationValidation, blobSizeLimitBytes: blobSizeLimitBytes).SyncContextSafeWait(waitTimeoutMilliseconds);
 
             IEnumerable<string> blocks = appendBlobBlockPreparer.PrepareAppendBlocks(textFormatter, new[] { logEvent });
 

--- a/src/Serilog.Sinks.AzureBlobStorage/Sinks/AzureBlobStorage/BlobNameFactory.cs
+++ b/src/Serilog.Sinks.AzureBlobStorage/Sinks/AzureBlobStorage/BlobNameFactory.cs
@@ -29,7 +29,7 @@ namespace Serilog.Sinks.AzureBlobStorage
             ValidatedBlobName();
         }
 
-        public string GetBlobName(DateTimeOffset dtoToApply, IReadOnlyDictionary<string, LogEventPropertyValue> properties, bool useUTCTimeZone = false)
+        public string GetBlobName(DateTimeOffset dtoToApply, IReadOnlyDictionary<string, LogEventPropertyValue> properties = null, bool useUTCTimeZone = false)
         {
             // Create copy of the base name
             string defaultName = (string)baseBlobName.Clone();
@@ -53,7 +53,7 @@ namespace Serilog.Sinks.AzureBlobStorage
                 }
                 else
                 {
-                    if (properties.ContainsKey(dateFormat))
+                    if (properties != null && properties.ContainsKey(dateFormat))
                     {
                         if (properties[dateFormat] is ScalarValue)
                         {

--- a/tests/Serilog.Sinks.AzureBlobStorage.UnitTest/BlobNameFactoryUT.cs
+++ b/tests/Serilog.Sinks.AzureBlobStorage.UnitTest/BlobNameFactoryUT.cs
@@ -8,7 +8,7 @@ namespace Serilog.Sinks.AzureBlobStorage.UnitTest
         [Fact(DisplayName = "Should throw validation exception due to invalid format characters.")]
         public void InvalidFormatCharacters()
         {
-            var dtoToApply = new DateTimeOffset(2018, 11, 5, 8, 30, 0, new TimeSpan(-5,0,0));
+            var dtoToApply = new DateTimeOffset(2018, 11, 5, 8, 30, 0, new TimeSpan(-5, 0, 0));
 
             Assert.Throws<ArgumentException>(() => new BlobNameFactory(@"{xx}\name.txt"));
         }
@@ -97,7 +97,7 @@ namespace Serilog.Sinks.AzureBlobStorage.UnitTest
             var dtoToApply = new DateTimeOffset(2018, 11, 5, 8, 30, 0, new TimeSpan(-5, 0, 0));
             var bn = new BlobNameFactory("webhook/{yyyy}/{MM}/{dd}/{HH}/logs.txt");
 
-            var result = bn.GetBlobName(dtoToApply, true);
+            var result = bn.GetBlobName(dtoToApply, useUTCTimeZone: true);
 
             Assert.Equal("webhook/2018/11/05/13/logs.txt", result);
         }

--- a/tests/Serilog.Sinks.AzureBlobStorage.UnitTest/Serilog.Sinks.AzureBlobStorage.UnitTest.csproj
+++ b/tests/Serilog.Sinks.AzureBlobStorage.UnitTest/Serilog.Sinks.AzureBlobStorage.UnitTest.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="FakeItEasy" Version="7.3.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.3.1" />
+    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="3.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
The aim is to allow the user to put a property like this storageFileName: "{yyyy}/{MM}/{TenantName}/log{yyyy}{MM}{dd}.txt", where TenantName is passed in the LogContext as LogContext.PushProperty("TenantName", tenantName);