### PR TITLE
Write to SelfLog instead of swallowing exceptions

### DIFF
--- a/src/Serilog.Sinks.AzureBlobStorage/Sinks/AzureBlobStorage/AzureBatchingBlobStorageSink.cs
+++ b/src/Serilog.Sinks.AzureBlobStorage/Sinks/AzureBlobStorage/AzureBatchingBlobStorageSink.cs
@@ -167,7 +167,9 @@ namespace Serilog.Sinks.AzureBlobStorage
                     await cloudBlobProvider.DeleteArchivedBlobsAsync(blobServiceClient, storageContainerName, blobNameFactory.GetBlobNameFormat(), retainedBlobCountLimit ?? default(int));
             }
             catch (Exception ex)
-            { }
+            { 
+                Debugging.SelfLog.WriteLine("Failed to write events to blob storage: {0} {1}", ex.Message, ex.StackTrace);
+            }
         }
 
         public void Emit(LogEvent logEvent)

--- a/src/Serilog.Sinks.AzureBlobStorage/Sinks/AzureBlobStorage/BlobNameFactory.cs
+++ b/src/Serilog.Sinks.AzureBlobStorage/Sinks/AzureBlobStorage/BlobNameFactory.cs
@@ -1,11 +1,7 @@
-using Serilog.Context;
 using Serilog.Events;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices.ComTypes;
-using System.Text;
 using System.Text.RegularExpressions;
 
 namespace Serilog.Sinks.AzureBlobStorage
@@ -103,7 +99,7 @@ namespace Serilog.Sinks.AzureBlobStorage
             }
             catch (Exception ex)
             {
-
+                Debugging.SelfLog.WriteLine($"Blob pattern was not in a parsable format: {0} {1}", ex.Message, ex.StackTrace);
             }
         }
 


### PR DESCRIPTION
This library writes to self log in other exceptional cases so it seems appropriate to also do them in a couple other places where exceptions are being swallowed.