### PR TITLE
bumping .net version of test project

### DIFF
--- a/tests/Serilog.Sinks.AzureBlobStorage.UnitTest/Serilog.Sinks.AzureBlobStorage.UnitTest.csproj
+++ b/tests/Serilog.Sinks.AzureBlobStorage.UnitTest/Serilog.Sinks.AzureBlobStorage.UnitTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
.NET core 3.1 is out support and was removed from Azure DevOps agents awhile back. Bumping to .NET 6.0 since it is LTS.