### PR TITLE
Fix for write in batches reaches the limits

### DIFF
--- a/src/Serilog.Sinks.AzureBlobStorage/LoggerConfigurationAzureBlobStorageExtensions.cs
+++ b/src/Serilog.Sinks.AzureBlobStorage/LoggerConfigurationAzureBlobStorageExtensions.cs
@@ -685,8 +685,7 @@ namespace Serilog
                     {
                         BatchSizeLimit = batchPostingLimit.GetValueOrDefault(DefaultBatchPostingLimit),
                         Period = period.GetValueOrDefault(DefaultPeriod),
-                        EagerlyEmitFirstEvent = true,
-                        QueueLimit = 10000
+                        EagerlyEmitFirstEvent = true
                     };
 
                     sink = new PeriodicBatchingSink(azureBlobStorageSink, batchingOptions);

--- a/src/Serilog.Sinks.AzureBlobStorage/Sinks/AzureBlobStorage/AzureBatchingBlobStorageSink.cs
+++ b/src/Serilog.Sinks.AzureBlobStorage/Sinks/AzureBlobStorage/AzureBatchingBlobStorageSink.cs
@@ -145,10 +145,18 @@ namespace Serilog.Sinks.AzureBlobStorage
 
             try
             {
+                AppendBlobClient blob     = null;
+                string           blobName = null;
+
                 foreach (var logEvent in logEvents)
                 {
-                    var blob = await cloudBlobProvider.GetCloudBlobAsync(blobServiceClient, storageContainerName,
-                        blobNameFactory.GetBlobName(lastEvent.Timestamp, logEvent.Properties, useUtcTimeZone), bypassBlobCreationValidation, contentType, blobSizeLimitBytes).ConfigureAwait(false);
+                    var newBlobName = blobNameFactory.GetBlobName(lastEvent.Timestamp, logEvent.Properties, useUtcTimeZone);
+                    if (blob == null || blobName != newBlobName)
+                    {
+                        blobName = newBlobName;
+                        blob = await cloudBlobProvider.GetCloudBlobAsync(blobServiceClient, storageContainerName, blobName,
+                                                                         bypassBlobCreationValidation, contentType, blobSizeLimitBytes).ConfigureAwait(false);
+                    }
 
                     if (!logEventsDictionary.ContainsKey(blob))
                     {


### PR DESCRIPTION
- Used the default for the QueueLimit (100000)
- Changed the call to get properties from BlobClient, because its takes too much time. This only needed when the blobname is changed.