### PR TITLE
Pin System.Text.Json with CVE fix only for frameworks != 'net8.0'

### DIFF
--- a/src/Serilog.Sinks.AzureBlobStorage/Serilog.Sinks.AzureBlobStorage.csproj
+++ b/src/Serilog.Sinks.AzureBlobStorage/Serilog.Sinks.AzureBlobStorage.csproj
@@ -41,11 +41,14 @@
 		<PackageReference Include="Azure.Storage.Blobs" Version="12.21.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
 		<PackageReference Include="Serilog" Version="4.0.0" />
-		<PackageReference Include="System.Text.Json" Version="8.0.4" />
+		
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' != 'net8.0'">
+		<PackageReference Include="System.Text.Json" Version="8.0.4" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
I think the CVE fix is needed only for old frameworks. NET 8.0 handles it with framework runtime updates.