### PR TITLE
Set IsAotCompatible=true for .NET8.0

### DIFF
--- a/src/Serilog.Sinks.AzureBlobStorage/Serilog.Sinks.AzureBlobStorage.csproj
+++ b/src/Serilog.Sinks.AzureBlobStorage/Serilog.Sinks.AzureBlobStorage.csproj
@@ -25,6 +25,7 @@
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
 		<IsAotCompatible>true</IsAotCompatible>
+		<JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Serilog.Sinks.AzureBlobStorage/Serilog.Sinks.AzureBlobStorage.csproj
+++ b/src/Serilog.Sinks.AzureBlobStorage/Serilog.Sinks.AzureBlobStorage.csproj
@@ -23,12 +23,12 @@
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageIcon>serilog-sink-nuget.png</PackageIcon>
 	</PropertyGroup>
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+		<IsAotCompatible>true</IsAotCompatible>
+	</PropertyGroup>
 
 	<ItemGroup>
 		<None Include="../../LICENSE.md" Pack="true" PackagePath="/" />
-	</ItemGroup>
-
-	<ItemGroup>
 		<None Include="../../README.md" Pack="true" PackagePath="/" />
 		<None Include="..\..\serilog-sink-nuget.png">
 			<Pack>True</Pack>
@@ -41,14 +41,11 @@
 		<PackageReference Include="Azure.Storage.Blobs" Version="12.21.1" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
 		<PackageReference Include="Serilog" Version="4.0.1" />
-		
 	</ItemGroup>
-
 	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' != 'net8.0'">
 		<PackageReference Include="System.Text.Json" Version="8.0.4" />
 	</ItemGroup>
-
 </Project>


### PR DESCRIPTION
This activates warnings if the code is not compatible to AOT. There are no active warnings to fix for now. 
Information: https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot